### PR TITLE
배포 상태의 머니로그 api 경로 수정

### DIFF
--- a/src/lib/api/moneylog.js
+++ b/src/lib/api/moneylog.js
@@ -3,7 +3,7 @@ import { setToken } from './auth';
 
 const baseUrl = process.env.REACT_APP_BACKEND_BASE_URL
   ? `${process.env.REACT_APP_BACKEND_BASE_URL}/api/assets/money-log`
-  : '/api/money-log';
+  : '/api/assets/money-log';
 
 export const getMoneyLog = async (year, month, date) => {
   setToken();


### PR DESCRIPTION
머니로그 api : 로컬에서는 잘 요청되는데 배포된 사이트에서는 `404` 에러 발생
-> 배포 상태의 api 경로를 잘못 작성하여 수정