### PR TITLE
커뮤니티 api 요청 이후 로직 수정

### DIFF
--- a/src/containers/PostDetailContainer.js
+++ b/src/containers/PostDetailContainer.js
@@ -1,26 +1,24 @@
 import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import Loading from '../components/common/Loading';
 import PostDetail from '../components/Community/PostDetail';
 import DoubleCheckModal from '../components/common/DoubleCheckModal';
 import { deletePost, getPost, likePost, scrapPost } from '../lib/api/post';
 
 function PostDetailContainer({ id, category }) {
-  const { data, status, remove } = useQuery(
-    ['postDetail', id],
-    () => getPost(id),
-    {
-      onSuccess: (data) => {
-        setLike(data.myLike);
-        setScrap(data.myScrap);
-      },
-      refetchOnWindowFocus: false,
+  const queryClient = useQueryClient();
+  const { data, status } = useQuery(['postDetail', id], () => getPost(id), {
+    onSuccess: (data) => {
+      setLike(data.myLike);
+      setScrap(data.myScrap);
     },
-  );
+    refetchOnWindowFocus: false,
+  });
   const deleteMutation = useMutation(() => deletePost(id), {
     onSuccess: () => {
       navigate(`/community/${category}`, { replace: true });
+      queryClient.useQueryClient(['recentPosts', category]);
     },
   });
   const scrapMutation = useMutation(() => scrapPost(id), {
@@ -43,9 +41,6 @@ function PostDetailContainer({ id, category }) {
       }
     }, 2000);
   }, [like]);
-  useEffect(() => {
-    return () => remove();
-  }, []);
 
   const onScrap = () => {
     if (scrap) {

--- a/src/pages/CommunityPage/CommunityListPage.js
+++ b/src/pages/CommunityPage/CommunityListPage.js
@@ -24,8 +24,7 @@ const StyledButton = styled(Button)`
 
 function CommunityListPage() {
   const { category } = useParams();
-  // category에 따라 게시물 가져오기 (api 요청)
-  const { data, hasNextPage, status, fetchNextPage, remove } = useInfiniteQuery(
+  const { data, hasNextPage, status, fetchNextPage } = useInfiniteQuery(
     ['recentPosts', category],
     ({ pageParam = 0 }) => getRecentPosts(category, pageParam),
     {
@@ -58,10 +57,6 @@ function CommunityListPage() {
       observer.unobserve(el);
     };
   }, [hasNextPage, loadMoreRef.current]);
-
-  useEffect(() => {
-    return () => remove();
-  }, []);
 
   if (status === 'loading') {
     return (

--- a/src/pages/CommunityPage/CommunityWritePage.js
+++ b/src/pages/CommunityPage/CommunityWritePage.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import Loading from '../../components/common/Loading';
 import { NotLogin } from '../../components/common/NotLogin';
 import WriteActionButtons from '../../components/common/WriteActionButtons';
@@ -27,14 +27,17 @@ function CommunityWritePage() {
   const { auth } = useSelector(({ login }) => login);
   const { title, content, saveImageUrl, imageFiles, postId, moneyLogImages } =
     useSelector(({ post }) => post);
+  const queryClient = useQueryClient();
   const createMutation = useMutation((newPost) => createPost(newPost), {
     onSuccess: (data) => {
       navigate(`/community/${category}/${data.postId}`, { replace: true });
+      queryClient.refetchQueries(['postDetail', data.postId]);
     },
   });
   const editMutation = useMutation((post) => editPost(post), {
     onSuccess: (data) => {
       navigate(`/community/${category}/${data.postId}`, { replace: true });
+      queryClient.refetchQueries(['postDetail', data.postId]);
     },
   });
   const dispatch = useDispatch();
@@ -67,7 +70,7 @@ function CommunityWritePage() {
     };
   }, []);
 
-  const onCancel = () => navigate('/community');
+  const onCancel = () => navigate(`/community/${category}`);
   const onSubmit = async (e) => {
     e.preventDefault();
     if (title === '' || content === '') {


### PR DESCRIPTION
- `useQuery`가 반환하는 `remove` 함수 이용하지 않고 `queryClient.refetchQueries`로 변경